### PR TITLE
Modifications to the 7 segment font

### DIFF
--- a/src/decoder.v
+++ b/src/decoder.v
@@ -28,7 +28,7 @@ module seg7 (
             6:  segments = 7'b1111101;
             7:  segments = 7'b0000111;
             8:  segments = 7'b1111111;
-            9:  segments = 7'b1100111;
+            9:  segments = 7'b1101111;
             10: segments = 7'b1110111;
             11: segments = 7'b1111100;
             12: segments = 7'b0111001;

--- a/src/decoder.v
+++ b/src/decoder.v
@@ -25,11 +25,17 @@ module seg7 (
             3:  segments = 7'b1001111;
             4:  segments = 7'b1100110;
             5:  segments = 7'b1101101;
-            6:  segments = 7'b1111100;
+            6:  segments = 7'b1111101;
             7:  segments = 7'b0000111;
             8:  segments = 7'b1111111;
             9:  segments = 7'b1100111;
-            default:    
+            10: segments = 7'b1110111;
+            11: segments = 7'b1111100;
+            12: segments = 7'b0111001;
+            13: segments = 7'b1011110;
+            14: segments = 7'b1111001;
+            15: segments = 7'b1110001;
+	    default:
                 segments = 7'b0000000;
         endcase
     end

--- a/src/test.py
+++ b/src/test.py
@@ -3,7 +3,7 @@ from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, FallingEdge, Timer, ClockCycles
 
 
-segments = [ 63, 6, 91, 79, 102, 109, 125, 7, 127, 103 ]
+segments = [ 63, 6, 91, 79, 102, 109, 125, 7, 127, 111 ]
 
 @cocotb.test()
 async def test_7seg(dut):

--- a/src/test.py
+++ b/src/test.py
@@ -3,7 +3,7 @@ from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, FallingEdge, Timer, ClockCycles
 
 
-segments = [ 63, 6, 91, 79, 102, 109, 124, 7, 127, 103 ]
+segments = [ 63, 6, 91, 79, 102, 109, 125, 7, 127, 103 ]
 
 @cocotb.test()
 async def test_7seg(dut):


### PR DESCRIPTION
This adds "tails" to the 6 and the 9, so that the font matches this image:
![image](https://github.com/TinyTapeout/tt05-verilog-demo/assets/477768/d822c203-7354-4ff8-b822-ceeab1e0e054)

Additionally, it adds decoding for values 10-15 as `A, b, C, d, E, F`, this is unused by this demo project but is likely to be generally useful to people using the decoder for debug purposes in their own projects.